### PR TITLE
More robust post-install-command?

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "post-create-project-cmd" : [
-            "php --run \"touch('.env');\""
+            "php post.php"
         ]
     },
     "minimum-stability": "dev"

--- a/post.php
+++ b/post.php
@@ -1,0 +1,57 @@
+<?php
+// @codingStandardsIgnoreFile
+
+
+// Create env file
+touch('.env');
+echo "- Created .env\n";
+
+// Remove Radar meta
+array_map(
+    'unlink',
+    [
+        'CONTRIBUTING.md',
+        'LICENSE',
+        'CHANGES.md',
+        'README.md',
+        'src/.placeholder'
+    ]
+);
+echo "- Removed Radar meta\n";
+
+
+// Remove Radar docs
+array_map('unlink', glob('docs/*'));
+rmdir('docs');
+echo "- Removed Radar docs\n";
+
+// Keep composer.lock for projects
+// http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
+file_put_contents(
+    '.gitignore',
+    '/.env' . PHP_EOL . '/vendor' . PHP_EOL
+);
+echo "- Initializeid .gitignore\n";
+
+// Cleanup composer.json
+$composerJson = json_decode(file_get_contents('composer.json'), true);
+
+unset(
+    $composerJson['name'],
+    $composerJson['description'],
+    $composerJson['license'],
+    $composerJson['license'],
+    $composerJson['scripts']
+);
+
+file_put_contents(
+    'composer.json',
+    json_encode($composerJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+);
+echo "-  Cleaned composer.json\n";
+
+
+// Remove post install command
+unlink('post.php');
+echo "-  Removed post.php command\n";
+


### PR DESCRIPTION
This is pretty sloppy, and not totally thought through, but I thought I'd throw this out there and see what people think before spending too much time on it. This is really just to illustrate the idea.

Currently, when using composer to create a Radar project, the result includes a number of things which would not pertain to the project you are creating. Specifically, I'm thinking the following would make the result of `create-project` more "ready to go".
#### Remove Radar specific "meta files"
- CONTRIBUTING.md, 
- LICENSE,
- CHANGES.md, 
- README.md, and 
- src/.placeholder

src/.placeholder is obviously just a place holder, and seems unnecessary in a real project.

The other files, all have contents which pertains to the Radar project itself and not the project that one is creating. 

That is **unless** the intention here is to _encourage_ the use of this standard. In which case, I would think that the contents of CONTRIBUTING is generic enough, and possibly CHANGES (although I would just assume encourage a boiler plate like http://keepachangelog.com/). However, the README is clearly Radar specific, and I would think should either be blanked or filled with something more generic. Additionally, unless the intention is to encourage use of the MIT license, I would think that would go away.
#### Remove docs

I suppose the docs somewhat pertain to the project one is creating, but again, dont seem like the docs I would want to ship with the application I'm creating.
#### Don't ignore composer.lock

In my understanding, "libraries" should ignore the lock file, but "projects" should not.
https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
#### Make composer.json more generic

The Radar name, description, license, and scripts in composer.json could be removed from the project's composer.json after install, as again this all pertains to radar, and not the project one is creating.
#### Get rid of the installer

In this, I have separated the "install" script into a separate file, which could be removed after creation.
### Doing it better

Again, this is pretty sloppy, and  just to demonstrate some thoughts. I'm not actually sure if any of this flies in the face of convention or best practices or desires, so I didn't spend any real time on it. 

I believe composer has a IO utilities available to actual do this kind of thing nicer with prompting for user input, etc. which is how it should probably be done. Then wrap it all in something like `Radar\Project\Install::Command` or something...

Thoughts?
